### PR TITLE
Signup login page restyling

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -15,6 +15,7 @@
   },
   "rules": {
     // suppress errors for missing 'import React' in files
+    "@typescript-eslint/no-unused-vars": ["warn"],
    "react/react-in-jsx-scope": "off",
    "react/prop-types": "off",
    "react-hooks/rules-of-hooks": "error",

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -21,4 +21,5 @@
    "react-hooks/rules-of-hooks": "error",
    "react-hooks/exhaustive-deps": "error"
   }
+
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { CssBaseline } from '@mui/material';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/material/styles';
 import { theme } from './themes/theme';
 import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import Login from './pages/Login/Login';

--- a/client/src/components/AuthFooter/AuthFooter.tsx
+++ b/client/src/components/AuthFooter/AuthFooter.tsx
@@ -1,31 +1,31 @@
-import Button from '@mui/material/Button';
+import Link from '@mui/material/Link';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import { Link } from 'react-router-dom';
+import { Link as LinkComponent } from 'react-router-dom';
 import useStyles from './useStyles';
 
 interface Props {
   linkTo: string;
   asideText: string;
-  btnText: string;
+  linkText: string;
 }
 
-const AuthFooter = ({ linkTo, asideText, btnText }: Props): JSX.Element => {
+const AuthFooter = ({ linkTo, asideText, linkText }: Props): JSX.Element => {
   const classes = useStyles();
 
   return (
     <Box
       p={1}
       display="flex"
-      justifyContent="flex-end"
-      alignSelf="flex-end"
+      justifyContent="center"
+      alignItems="center"
       marginRight={5}
       className={classes.authHeader}
     >
       <Typography className={classes.accAside}>{asideText}</Typography>
-      <Button component={Link} to={linkTo} color="inherit" className={classes.accBtn} variant="contained">
-        {btnText}
-      </Button>
+      <Link component={LinkComponent} to={linkTo} color="inherit" className={classes.linkText}>
+        {linkText}
+      </Link>
     </Box>
   );
 };

--- a/client/src/components/AuthFooter/useStyles.ts
+++ b/client/src/components/AuthFooter/useStyles.ts
@@ -14,16 +14,16 @@ const useStyles = makeStyles((theme: Theme) => ({
     whiteSpace: 'nowrap',
     display: 'flex',
     alignItems: 'center',
-    padding: '1rem',
+    padding: '5px',
   },
-  accBtn: {
-    width: 170,
-    height: 54,
-    borderRadius: theme.shape.borderRadius,
-    filter: 'drop-shadow(0px 2px 6px rgba(74,106,149,0.2))',
-    backgroundColor: '#ffffff',
-    color: '#3a8dff',
-    boxShadow: 'none',
+  linkText: {
+    fontSize: 14,
+    color: '#b0b0b0',
+    fontWeight: 400,
+    textAlign: 'center',
+    whiteSpace: 'nowrap',
+    display: 'flex',
+    alignItems: 'center',
   },
 }));
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,13 +1,10 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Arial", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  font-family: Roboto, Arial;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
+  font-family: Roboto, Arial;
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+  font-family: -apple-system, BlinkMacSystemFont, "Arial", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -6,7 +6,7 @@ import { FormikHelpers } from 'formik';
 import useStyles from './useStyles';
 import login from '../../helpers/APICalls/login';
 import LoginForm from './LoginForm/LoginForm';
-import AuthHeader from '../../components/AuthHeader/AuthHeader';
+import AuthFooter from '../../components/AuthFooter/AuthFooter';
 import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
 
@@ -36,20 +36,20 @@ export default function Login(): JSX.Element {
   };
 
   return (
-    <Grid container component="main" className={classes.root}>
+    <Grid maxHeight={500} container direction="column" spacing={3} justifyContent="center" alignItems="center">
       <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} square>
         <Box
+          maxHeight={500}
           display="flex"
-          justifyContent="space-between"
-          alignItems="flex-start"
+          justifyContent="center"
+          alignItems="center"
           flexDirection="column"
           className={classes.authWrapper}
         >
-          <AuthHeader linkTo="/signup" asideText="Don't have an account?" btnText="Create account" />
-          <Box width="100%" maxWidth={450} p={3} alignSelf="center">
+          <Box height="100%" maxHeight={500} width="100%" maxWidth={600} p={3} alignSelf="center">
             <Grid container>
               <Grid item xs>
-                <Typography className={classes.welcome} component="h1" variant="h5">
+                <Typography className={classes.welcome} component="h1" variant="h3">
                   Welcome back!
                 </Typography>
               </Grid>
@@ -57,6 +57,7 @@ export default function Login(): JSX.Element {
             <LoginForm handleSubmit={handleSubmit} />
           </Box>
           <Box p={1} alignSelf="center" />
+          <AuthFooter linkTo="/signup" asideText="Sign up" linkText="here" />
         </Box>
       </Grid>
     </Grid>

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -48,11 +48,12 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
           <TextField
             id="email"
-            label={<Typography className={classes.label}>E-mail address</Typography>}
+            label={'Email Address'}
             fullWidth
             margin="normal"
             InputLabelProps={{
               shrink: true,
+              classes: { root: classes.label },
             }}
             InputProps={{
               classes: { input: classes.inputs },
@@ -67,11 +68,12 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
           />
           <TextField
             id="password"
-            label={<Typography className={classes.label}>Password</Typography>}
+            label={'Password'}
             fullWidth
             margin="normal"
             InputLabelProps={{
               shrink: true,
+              classes: { root: classes.label },
             }}
             InputProps={{
               classes: { input: classes.inputs },

--- a/client/src/pages/Login/LoginForm/useStyles.ts
+++ b/client/src/pages/Login/LoginForm/useStyles.ts
@@ -6,15 +6,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '100%', // Fix IE 11 issue.
     marginTop: theme.spacing(1),
   },
+  textField: {
+    '&.MuiTextField-root': {
+      marginBottom: theme.spacing(3),
+    },
+  },
   label: {
-    fontSize: 19,
-    color: 'rgb(0,0,0,0.4)',
-    paddingLeft: '5px',
+    marginTop: theme.spacing(-2),
+    marginLeft: theme.spacing(-2),
   },
   inputs: {
-    marginTop: '.8rem',
-    height: '2rem',
-    padding: '5px',
+    padding: '1px',
   },
   forgot: {
     paddingRight: 10,
@@ -26,9 +28,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: 160,
     height: 56,
     borderRadius: theme.shape.borderRadius,
-    marginTop: 49,
     fontSize: 16,
-    backgroundColor: '#3a8dff',
+    backgroundColor: '#f14140',
     fontWeight: 'bold',
   },
 }));

--- a/client/src/pages/Login/useStyles.ts
+++ b/client/src/pages/Login/useStyles.ts
@@ -8,7 +8,6 @@ const useStyles = makeStyles(() => ({
     },
   },
   authWrapper: {
-    display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     minHeight: '100vh',

--- a/client/src/pages/Login/useStyles.ts
+++ b/client/src/pages/Login/useStyles.ts
@@ -8,14 +8,20 @@ const useStyles = makeStyles(() => ({
     },
   },
   authWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     minHeight: '100vh',
     paddingTop: 23,
   },
   welcome: {
-    fontSize: 26,
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+    fontSize: 40,
     paddingBottom: 20,
     color: '#000000',
-    fontWeight: 700,
+    fontWeight: 1000,
   },
 }));
 

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -1,13 +1,13 @@
 import Paper from '@mui/material/Paper';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
-import { Link, TextField } from '@mui/material';
+import AuthFooter from '../../components/AuthFooter/AuthFooter';
 import Typography from '@mui/material/Typography';
 import { FormikHelpers } from 'formik';
 import useStyles from './useStyles';
 import register from '../../helpers/APICalls/register';
 import SignUpForm from './SignUpForm/SignUpForm';
-import AuthHeader from '../../components/AuthHeader/AuthHeader';
+import AuthHeader from '../../components/AuthFooter/AuthFooter';
 import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
 
@@ -38,17 +38,17 @@ export default function Register(): JSX.Element {
   };
 
   return (
-    <Grid container direction="column" spacing={3} justifyContent="center" alignItems="center">
+    <Grid maxHeight={500} container direction="column" spacing={3} justifyContent="center" alignItems="center">
       <Grid item xs={8} sm={8} md={7} elevation={6} component={Paper} square>
         <Box
+          maxHeight={500}
           display="flex"
           justifyContent="center"
           alignItems="center"
           flexDirection="column"
           className={classes.authWrapper}
         >
-          <AuthHeader linkTo="/login" asideText="Already have an account?" btnText="Login" />
-          <Box width="100%" maxWidth={450} p={3} alignSelf="center">
+          <Box height="100%" maxHeight={500} width="100%" maxWidth={600} p={3} alignSelf="center">
             <Grid container>
               <Grid item xs>
                 <Typography className={classes.welcome} component="h1" variant="h3">
@@ -57,9 +57,9 @@ export default function Register(): JSX.Element {
               </Grid>
             </Grid>
             <SignUpForm handleSubmit={handleSubmit} />
-            <Link href="/login">Login</Link>
           </Box>
           <Box p={1} alignSelf="center" />
+          <AuthFooter linkTo="/login" asideText="Already a member?" linkText="Login" />
         </Box>
       </Grid>
     </Grid>

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -38,12 +38,12 @@ export default function Register(): JSX.Element {
   };
 
   return (
-    <Grid container component="main" className={classes.root}>
-      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} square>
+    <Grid container direction="column" spacing={3} justifyContent="center" alignItems="center">
+      <Grid item xs={8} sm={8} md={7} elevation={6} component={Paper} square>
         <Box
           display="flex"
-          justifyContent="space-between"
-          alignItems="flex-start"
+          justifyContent="center"
+          alignItems="center"
           flexDirection="column"
           className={classes.authWrapper}
         >

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -1,6 +1,7 @@
 import Paper from '@mui/material/Paper';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
+import { Link, TextField } from '@mui/material';
 import Typography from '@mui/material/Typography';
 import { FormikHelpers } from 'formik';
 import useStyles from './useStyles';
@@ -50,12 +51,13 @@ export default function Register(): JSX.Element {
           <Box width="100%" maxWidth={450} p={3} alignSelf="center">
             <Grid container>
               <Grid item xs>
-                <Typography className={classes.welcome} component="h1" variant="h5">
-                  Create an account
+                <Typography className={classes.welcome} component="h1" variant="h3">
+                  Sign Up
                 </Typography>
               </Grid>
             </Grid>
             <SignUpForm handleSubmit={handleSubmit} />
+            <Link href="/login">Login</Link>
           </Box>
           <Box p={1} alignSelf="center" />
         </Box>

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -52,8 +52,27 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
       {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
           <TextField
+            id="email"
+            label={<Typography className={classes.label}>Email address</Typography>}
+            fullWidth
+            margin="normal"
+            InputLabelProps={{
+              shrink: true,
+            }}
+            InputProps={{
+              classes: { input: classes.inputs },
+            }}
+            name="email"
+            autoComplete="email"
+            helperText={touched.email ? errors.email : ''}
+            error={touched.email && Boolean(errors.email)}
+            value={values.email}
+            onChange={handleChange}
+          />
+
+          <TextField
             id="username"
-            label={<Typography className={classes.label}>Username</Typography>}
+            label={<Typography className={classes.label}>Name</Typography>}
             fullWidth
             margin="normal"
             InputLabelProps={{
@@ -70,24 +89,7 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             value={values.username}
             onChange={handleChange}
           />
-          <TextField
-            id="email"
-            label={<Typography className={classes.label}>E-mail address</Typography>}
-            fullWidth
-            margin="normal"
-            InputLabelProps={{
-              shrink: true,
-            }}
-            InputProps={{
-              classes: { input: classes.inputs },
-            }}
-            name="email"
-            autoComplete="email"
-            helperText={touched.email ? errors.email : ''}
-            error={touched.email && Boolean(errors.email)}
-            value={values.email}
-            onChange={handleChange}
-          />
+
           <TextField
             id="password"
             label={<Typography className={classes.label}>Password</Typography>}
@@ -109,7 +111,7 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
 
           <Box textAlign="center" marginTop={5}>
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
-              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Create'}
+              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'SIGN UP'}
             </Button>
           </Box>
         </form>

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -117,7 +117,7 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
 
           <Box textAlign="center" marginTop={5}>
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
-              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'SIGN UP'}
+              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'sign up'}
             </Button>
           </Box>
         </form>

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -53,15 +53,17 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
           <TextField
             id="email"
-            label={<Typography className={classes.label}>Email address</Typography>}
+            label={'Email Address'}
             fullWidth
             margin="normal"
             InputLabelProps={{
               shrink: true,
+              classes: { root: classes.label },
             }}
             InputProps={{
               classes: { input: classes.inputs },
             }}
+            placeholder="Your email"
             name="email"
             autoComplete="email"
             helperText={touched.email ? errors.email : ''}
@@ -71,18 +73,20 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
           />
 
           <TextField
-            id="username"
-            label={<Typography className={classes.label}>Name</Typography>}
+            id="name"
+            label={'Name'}
             fullWidth
             margin="normal"
             InputLabelProps={{
               shrink: true,
+              classes: { root: classes.label },
             }}
             InputProps={{
               classes: { input: classes.inputs },
             }}
-            name="username"
-            autoComplete="username"
+            placeholder="Your name"
+            name="name"
+            autoComplete="name"
             autoFocus
             helperText={touched.username ? errors.username : ''}
             error={touched.username && Boolean(errors.username)}
@@ -92,16 +96,18 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
 
           <TextField
             id="password"
-            label={<Typography className={classes.label}>Password</Typography>}
+            label={'Password'}
             fullWidth
             margin="normal"
             InputLabelProps={{
               shrink: true,
+              classes: { root: classes.label },
             }}
             InputProps={{
               classes: { input: classes.inputs },
             }}
             type="password"
+            placeholder="Create a password"
             autoComplete="current-password"
             helperText={touched.password ? errors.password : ''}
             error={touched.password && Boolean(errors.password)}

--- a/client/src/pages/SignUp/SignUpForm/useStyles.ts
+++ b/client/src/pages/SignUp/SignUpForm/useStyles.ts
@@ -9,7 +9,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   label: {
     fontSize: 19,
     color: 'rgb(0,0,0,0.4)',
-    paddingLeft: '5px',
+    paddingBottom: '10px',
   },
   inputs: {
     marginTop: '1rem',
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: 56,
     borderRadius: theme.shape.borderRadius,
     fontSize: 16,
-    backgroundColor: '#3a8dff',
+    backgroundColor: '#f14140',
     fontWeight: 'bold',
   },
 }));

--- a/client/src/pages/SignUp/SignUpForm/useStyles.ts
+++ b/client/src/pages/SignUp/SignUpForm/useStyles.ts
@@ -6,15 +6,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '100%', // Fix IE 11 issue.
     marginTop: theme.spacing(1),
   },
+  textField: {
+    '&.MuiTextField-root': {
+      marginBottom: theme.spacing(3),
+    },
+  },
   label: {
-    fontSize: 19,
-    color: 'rgb(0,0,0,0.4)',
-    paddingBottom: '10px',
+    marginTop: theme.spacing(-2),
+    marginLeft: theme.spacing(-2),
   },
   inputs: {
-    marginTop: '1rem',
-    height: '2rem',
-    padding: '5px',
+    padding: '1px',
   },
   forgot: {
     paddingRight: 10,

--- a/client/src/pages/SignUp/useStyles.ts
+++ b/client/src/pages/SignUp/useStyles.ts
@@ -9,9 +9,8 @@ const useStyles = makeStyles(() => ({
   },
   authWrapper: {
     display: 'flex',
-    alignItems: 'flex-start',
-    justifyContent: 'space-between',
-    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
     minHeight: '100vh',
     paddingTop: 23,
   },
@@ -22,7 +21,7 @@ const useStyles = makeStyles(() => ({
     fontSize: 40,
     paddingBottom: 20,
     color: '#000000',
-    fontWeight: 800,
+    fontWeight: 1000,
   },
 }));
 

--- a/client/src/pages/SignUp/useStyles.ts
+++ b/client/src/pages/SignUp/useStyles.ts
@@ -16,10 +16,13 @@ const useStyles = makeStyles(() => ({
     paddingTop: 23,
   },
   welcome: {
-    fontSize: 26,
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+    fontSize: 40,
     paddingBottom: 20,
     color: '#000000',
-    fontWeight: 700,
+    fontWeight: 800,
   },
 }));
 

--- a/client/src/pages/SignUp/useStyles.ts
+++ b/client/src/pages/SignUp/useStyles.ts
@@ -4,7 +4,7 @@ const useStyles = makeStyles(() => ({
   root: {
     minHeight: '100vh',
     '& .MuiInput-underline:before': {
-      borderBottom: '1.2px solid rgba(0, 0, 0, 0.2)',
+      fontSize: 40,
     },
   },
   authWrapper: {

--- a/client/src/themes/theme.ts
+++ b/client/src/themes/theme.ts
@@ -2,15 +2,16 @@ import { createTheme } from '@mui/material/styles';
 
 export const theme = createTheme({
   typography: {
-    fontFamily: '"Open Sans", "sans-serif", "Roboto"',
+    fontFamily: '"Arial", "Roboto"',
     fontSize: 12,
     button: {
       textTransform: 'none',
-      fontWeight: 700,
+      fontWeight: 900,
+      fontSize: 14,
     },
   },
   palette: {
-    primary: { main: '#3A8DFF' },
+    primary: { main: '#f14140' },
   },
   shape: {
     borderRadius: 5,

--- a/client/src/themes/theme.ts
+++ b/client/src/themes/theme.ts
@@ -5,7 +5,7 @@ export const theme = createTheme({
     fontFamily: '"Roboto", "Arial"',
     fontSize: 12,
     button: {
-      textTransform: 'none',
+      textTransform: 'uppercase',
       fontWeight: 900,
       fontSize: 14,
     },

--- a/client/src/themes/theme.ts
+++ b/client/src/themes/theme.ts
@@ -2,7 +2,7 @@ import { createTheme } from '@mui/material/styles';
 
 export const theme = createTheme({
   typography: {
-    fontFamily: '"Arial", "Roboto"',
+    fontFamily: '"Roboto", "Arial"',
     fontSize: 12,
     button: {
       textTransform: 'none',
@@ -17,4 +17,27 @@ export const theme = createTheme({
     borderRadius: 5,
   },
   spacing: 6,
+  components: {
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          border: '1px solid #000',
+          height: 42,
+        },
+        notchedOutline: {
+          display: 'none',
+        },
+      },
+    },
+
+    MuiInputLabel: {
+      styleOverrides: {
+        root: {
+          color: '#000',
+          fontSize: 14,
+          fontWeight: '700',
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
### What this PR does (required):
- created login and register frontend designed from assets of the mockup

### Screenshots / Videos (front-end only):
![mockup](https://i.imgur.com/pOCOKw8.png)
![mockup](https://i.imgur.com/wIL4iOp.png)

### Any information needed to test this feature (required):
git clone this repo
cd into the client folder
run 'npm i'
run 'npm start'

### Any issues with the current functionality (optional):
It was my first time using Material UI so it was difficult getting basic css styles changed compared to what im used to in Bootstrap, but I eventually got the styles to look as close as I could. I am also new to Typescript so I am still not used to all of its features. 
